### PR TITLE
writeFloatBE changed to writeFloatLE

### DIFF
--- a/simple-js-examples/simple-pt-example.js
+++ b/simple-js-examples/simple-pt-example.js
@@ -102,10 +102,10 @@ EdgePTExample.prototype.registerProtocolTranslator = async function() {
 EdgePTExample.prototype._createDeviceParams = function(deviceId, temperatureValue, setPointValue) {
     // Values are always Base64 encoded strings.
     let temperature = Buffer.allocUnsafe(4);
-    temperature.writeFloatBE(temperatureValue)
+    temperature.writeFloatLE(temperatureValue)
     temperature = temperature.toString('base64');
     let setPoint = Buffer.allocUnsafe(4);
-    setPoint.writeFloatBE(setPointValue);
+    setPoint.writeFloatLE(setPointValue);
     setPoint = setPoint.toString('base64');
 
     // An IPSO/LwM2M temperature sensor and set point sensor (thermostat)


### PR DESCRIPTION
floats weren't being encoded to valid base64 if they're converted to strings with writeFloatBE, using writeFloatLE instead causes the messages to be received and parsed correctly by the PDM console