### PR TITLE
use double to fix conversion errors

### DIFF
--- a/simple-js-examples/simple-grm-example.js
+++ b/simple-js-examples/simple-grm-example.js
@@ -102,8 +102,8 @@ EdgeGRMExample.prototype._createResourceParams = function(value1, value2) {
     // Values are always Base64 encoded strings.
     let resource1 = Buffer.from(value1).toString('base64')
 
-    let resource2 = Buffer.allocUnsafe(4);
-    resource2.writeFloatBE(value2);
+    let resource2 = Buffer.allocUnsafe(8);
+    resource2.writeDoubleBE(value2);
     resource2 = resource2.toString('base64');
 
     /* An IPSO/LwM2M Object is identified by a unique objectId
@@ -144,7 +144,7 @@ EdgeGRMExample.prototype.addResource = async function() {
     let self = this;
     return new Promise((resolve, reject) => {
 
-        params = self._createResourceParams("example-resource", 1.0);
+        params = self._createResourceParams("example-resource", 21.5);
 
         let timeout = setTimeout(() => {
             reject('Timeout');
@@ -172,7 +172,7 @@ EdgeGRMExample.prototype.updateResourceValue = async function() {
             reject('Timeout');
         }, TIMEOUT);
 
-        let params = self._createResourceParams("example-resource", 2.0);
+        let params = self._createResourceParams("example-resource", 19.4);
 
 
         self.client.send('write_resource_value', params,
@@ -190,8 +190,8 @@ EdgeGRMExample.prototype.updateResourceValue = async function() {
 EdgeGRMExample.prototype.exposeWriteMethod = function() {
     let self = this;
     self.client.expose('write', (params, response) => {
-        let valueBuff = new Buffer.from(params.value, 'base64');
-        let value = valueBuff.toString('utf-8');
+        // only '/33001/0/1' resource is WRITABLE, assume double
+        let value = new Buffer.from(params.value, 'base64').readDoubleBE();
         let resourcePath = params.uri.objectId + '/' + params.uri.objectInstanceId
             + '/' + params.uri.resourceId;
 

--- a/simple-js-examples/simple-pt-example.js
+++ b/simple-js-examples/simple-pt-example.js
@@ -101,11 +101,11 @@ EdgePTExample.prototype.registerProtocolTranslator = async function() {
 
 EdgePTExample.prototype._createDeviceParams = function(deviceId, temperatureValue, setPointValue) {
     // Values are always Base64 encoded strings.
-    let temperature = Buffer.allocUnsafe(4);
-    temperature.writeFloatBE(temperatureValue)
+    let temperature = Buffer.allocUnsafe(8);
+    temperature.writeDoubleBE(temperatureValue)
     temperature = temperature.toString('base64');
-    let setPoint = Buffer.allocUnsafe(4);
-    setPoint.writeFloatBE(setPointValue);
+    let setPoint = Buffer.allocUnsafe(8);
+    setPoint.writeDoubleBE(setPointValue);
     setPoint = setPoint.toString('base64');
 
     // An IPSO/LwM2M temperature sensor and set point sensor (thermostat)
@@ -188,8 +188,8 @@ EdgePTExample.prototype.updateExampleDeviceResources = async function(deviceId) 
     return new Promise((resolve, reject) => {
 
         params = self._createDeviceParams(deviceId,
-                                          19.5 /* temp */,
-                                          20.5 /* set point */);
+                                          17.4 /* temp */,
+                                          20.3 /* set point */);
 
         let timeout = setTimeout(() => {
             reject('Timeout');
@@ -210,6 +210,7 @@ EdgePTExample.prototype.updateExampleDeviceResources = async function(deviceId) 
 EdgePTExample.prototype.exposeWriteMethod = function() {
     let self = this;
     self.client.expose('write', (params, response) => {
+        // only '/3308/0/5900' resource is WRITABLE, assume double
         let value = new Buffer.from(params.value, 'base64').readDoubleBE();
         let resourcePath = params.uri.objectId + '/' + params.uri.objectInstanceId
             + '/' + params.uri.resourceId;


### PR DESCRIPTION
let's use 'double' throughout to countermeasure the float conversion error occurring in JS [1]

[1] https://programmersought.com/article/88806369606/

cc/ @DuncanFrazer 