### PR TITLE
Use install.sh from pelion-system-test-folder

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -94,10 +94,7 @@ jobs:
             python3 -m venv venv
           fi
           source venv/bin/activate
-          pip install --upgrade pip
-          pip install -U -r requirements.txt
-          pip install packages/*.whl
-          pip install -e systemtest-library
+          ./install.sh
           pytest -v --config_path=prod-edge-core-config.json --html=../${{ env.RESULT_HTML }} \
           --self-contained-html -log_cli=true --log-cli-level=DEBUG \
           --log-file=../${{ env.RESULT_LOG_FILE }} --log-file-level=DEBUG \


### PR DESCRIPTION
# Mbed Edge Examples pull request

## Description

Use the install.sh in pelion-system-tests to install it.
This avoids the issue with the raas-client wheel installation.

## Test instructions

Passing workflow run confirms it works.

## Check list

### Changelog
 
 - [N/A] `CHANGELOG.md` updated. -- workflow change


